### PR TITLE
Hotfix get box size

### DIFF
--- a/gautomatch/__init__.py
+++ b/gautomatch/__init__.py
@@ -33,7 +33,7 @@ from pwem.emlib.image import ImageHandler
 from .constants import *
 
 
-__version__ = '3.0.13'
+__version__ = '3.0.14'
 _logo = "gautomatch_logo.png"
 _references = ['Zhang']
 

--- a/gautomatch/protocols/protocol_gautomatch.py
+++ b/gautomatch/protocols/protocol_gautomatch.py
@@ -558,8 +558,13 @@ class ProtGautomatch(ProtParticlePickingAuto):
     def _getBoxSize(self):
         if self.boxSize and self.boxSize > 0:
             return self.boxSize.get()
-        else:
-            return self.inputReferences.get().getXDim() or 100
+
+        inputRefs = self.inputReferences.get()
+
+        if inputRefs and inputRefs.getXDim():
+            return inputRefs.getXDim()
+
+        return 100
 
     def _getMicrographDir(self, mic):
         """ Return an unique dir name for results of the micrograph. """


### PR DESCRIPTION
When inputReferences and boxSize were not provided, the following Exception occurred in _getBoxSize() method:
```
'NoneType' object has no attribute 'getXDim'
```