### PR TITLE
os module needs to be imported

### DIFF
--- a/gautomatch/viewers.py
+++ b/gautomatch/viewers.py
@@ -34,6 +34,7 @@ from pyworkflow.protocol.params import *
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pwem.viewers import ObjectView
 import pyworkflow.utils as pwutils
+import os
 
 from gautomatch.protocols import ProtGautomatch
 


### PR DESCRIPTION
gautomatch viewer fails with message

  File "/home/roberto/scipion3/Plugins/scipion-em-gautomatch/gautomatch/viewers.py", line 123, in _viewParam
    micsFn = os.path.join(tmpDir, micSet.getName() + '_micrographs.xmd')
NameError: name 'os' is not defined

proposed solution:  "os" needs to be imported. I guess in previous versions of scipion "os" was imported in another of the imported modules.

(I am using Scipion v3.0.12 - Eugenius)
