### PR TITLE
Hotfix for RST warnings for PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Gautomatch binaries will be installed automatically with the plugin, but you can
 
 Configuration variables
 -----------------------
-CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be `eval "$(/extra/miniconda3/bin/conda shell.bash hook)"`.
+CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be **eval "$(/extra/miniconda3/bin/conda shell.bash hook)"**.
 GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
 GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)
 GAUTOMATCH_BIN: Specific binary to use (default = Gautomatch_v0.56_sm30-75_cu10.1)

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Gautomatch binaries will be installed automatically with the plugin, but you can
 
 Configuration variables
 -----------------------
-CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be _eval "$(/extra/miniconda3/bin/conda shell.bash hook)"_.
+CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be :bash:`eval "$(/extra/miniconda3/bin/conda shell.bash hook)"`.
 GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
 GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)
 GAUTOMATCH_BIN: Specific binary to use (default = Gautomatch_v0.56_sm30-75_cu10.1)

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ b) Developer's version
 Gautomatch binaries will be installed automatically with the plugin, but you can also link an existing installation. 
 
 Configuration variables
-------------
+-----------------------
 CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be _eval "$(/extra/miniconda3/bin/conda shell.bash hook)"_.
 GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
 GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)

--- a/README.rst
+++ b/README.rst
@@ -53,10 +53,10 @@ Gautomatch binaries will be installed automatically with the plugin, but you can
 
 Configuration variables
 -----------------------
-CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be **eval "$(/extra/miniconda3/bin/conda shell.bash hook)"**.
-GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
-GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)
-GAUTOMATCH_BIN: Specific binary to use (default = Gautomatch_v0.56_sm30-75_cu10.1)
+- CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be **eval "$(/extra/miniconda3/bin/conda shell.bash hook)"**.
+- GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
+- GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)
+- GAUTOMATCH_BIN: Specific binary to use (default = Gautomatch_v0.56_sm30-75_cu10.1)
 
 Verifying
 ------------

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Gautomatch binaries will be installed automatically with the plugin, but you can
 
 Configuration variables
 -----------------------
-CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be :bash:`eval "$(/extra/miniconda3/bin/conda shell.bash hook)"`.
+CONDA_ACTIVATION_CMD: If undefined, it will rely on conda being in the PATH. An example of a conda activation cmd can be `eval "$(/extra/miniconda3/bin/conda shell.bash hook)"`.
 GAUTOMATCH_ENV_ACTIVATION: Command to activate the Gautomatch environment. This environment must have CUDA installed (cudatoolkit=10.1).
 GAUTOMATCH_HOME: Path to gautomatch binary containing folder (default = software/em/gautomatch-0.56)
 GAUTOMATCH_BIN: Specific binary to use (default = Gautomatch_v0.56_sm30-75_cu10.1)


### PR DESCRIPTION
Changed some lines in the README.rst for PyPI to not have any warning preventing publication